### PR TITLE
Added ticket response workflow using RAG

### DIFF
--- a/backend/api/__init__.py
+++ b/backend/api/__init__.py
@@ -26,6 +26,7 @@ def create_app():
     from routes.analytics import analytics_bp
     from routes.search import search_bp
     from routes.rag import rag_bp
+    from routes.users import users_bp
     
     app.register_blueprint(auth_bp)
     app.register_blueprint(tickets_bp)
@@ -33,5 +34,6 @@ def create_app():
     app.register_blueprint(analytics_bp)
     app.register_blueprint(search_bp)
     app.register_blueprint(rag_bp, url_prefix='/rag')
+    app.register_blueprint(users_bp)
     
     return app 

--- a/backend/config.py
+++ b/backend/config.py
@@ -1,0 +1,48 @@
+from supabase import create_client, Client
+from dotenv import load_dotenv
+import os
+import logging
+
+# Load environment variables
+load_dotenv()
+
+# Configure logging
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+# Initialize Supabase client
+supabase_url = os.getenv('SUPABASE_URL')
+supabase_key = os.getenv('SUPABASE_KEY')  # Use SUPABASE_KEY instead of SUPABASE_ANON_KEY
+
+if not supabase_url or not supabase_key:
+    raise ValueError("Missing required environment variables for Supabase configuration")
+
+supabase_client: Client = create_client(supabase_url, supabase_key)
+
+# Initialize Pinecone
+pinecone_api_key = os.getenv('PINECONE_API_KEY')
+if not pinecone_api_key:
+    raise ValueError("Missing required environment variable: PINECONE_API_KEY")
+
+class Config:
+    SUPABASE_URL = os.getenv('SUPABASE_URL')
+    SUPABASE_KEY = os.getenv('SUPABASE_KEY')  # anon key
+    #SUPABASE_SERVICE_KEY = os.getenv('SUPABASE_SERVICE_KEY')  # service role key
+    ALLOWED_ORIGINS = os.getenv('ALLOWED_ORIGINS', 'http://localhost:5173').split(',')
+
+# Initialize Supabase clients
+try:
+    # Regular client with anon key
+    supabase_client: Client = create_client(
+        Config.SUPABASE_URL,
+        Config.SUPABASE_KEY
+    )
+    
+    # Service role client for admin operations
+    #service_role_client: Client = create_client(
+    #    Config.SUPABASE_URL,
+    #    Config.SUPABASE_SERVICE_KEY
+    #)
+except Exception as e:
+    logger.error(f"Error initializing Supabase client: {str(e)}")
+    raise 

--- a/backend/routes/auth.py
+++ b/backend/routes/auth.py
@@ -2,6 +2,7 @@ from flask import Blueprint, request, jsonify
 from config import supabase_client, logger
 import traceback
 from functools import wraps
+from postgrest import APIError
 
 auth_bp = Blueprint('auth', __name__)
 
@@ -15,46 +16,28 @@ def register():
             
         email = data.get('email')
         password = data.get('password')
-        role = data.get('role', 'customer')
         
         if not email or not password:
             return jsonify({'error': 'Email and password are required'}), 400
         
-        logger.info(f"Registering user with email: {email}, role: {role}")
+        logger.info(f"Registering user with email: {email}")
         
-        # Register user with Supabase
+        # Basic registration with Supabase Auth
         auth_response = supabase_client.auth.sign_up({
             "email": email,
-            "password": password,
-            "options": {
-                "data": {
-                    "role": role
-                }
-            }
+            "password": password
         })
         
-        # Get the session information
-        session = auth_response.session
-        
-        if session:
-            return jsonify({
-                'message': 'Registration successful',
-                'access_token': session.access_token,
-                'user': {
-                    'email': email,
-                    'role': role
-                }
-            }), 201
-        else:
-            # Registration successful but needs email verification
+        if auth_response.user:
             return jsonify({
                 'message': 'Registration successful. Please check your email to verify your account.',
                 'user': {
-                    'email': email,
-                    'role': role
+                    'email': email
                 }
             }), 201
-        
+        else:
+            return jsonify({'error': 'Registration failed'}), 400
+            
     except Exception as e:
         logger.error(f"Registration error: {str(e)}")
         logger.error(traceback.format_exc())
@@ -87,18 +70,28 @@ def login():
         user = auth_response.user
         
         if session and user:
-            # Get the role from user metadata
-            role = user.user_metadata.get('role', 'customer')
-            logger.info(f"User role from metadata: {role}")
-            
-            return jsonify({
-                'access_token': session.access_token,
-                'refresh_token': session.refresh_token,
-                'user': {
-                    'email': user.email,
-                    'role': role
-                }
-            })
+            try:
+                # Fetch user profile from the profiles table
+                profile_response = supabase_client.table('profiles').select('role').eq('id', user.id).execute()
+                
+                if not profile_response.data:
+                    logger.error(f"No profile found for user {user.id}")
+                    return jsonify({'error': 'User profile not found'}), 404
+                
+                role = profile_response.data[0]['role']
+                logger.info(f"User role from profile: {role}")
+                
+                return jsonify({
+                    'access_token': session.access_token,
+                    'refresh_token': session.refresh_token,
+                    'user': {
+                        'email': user.email,
+                        'role': role
+                    }
+                })
+            except Exception as profile_error:
+                logger.error(f"Error fetching profile: {str(profile_error)}")
+                return jsonify({'error': 'Failed to fetch user profile'}), 500
         else:
             return jsonify({'error': 'Login failed'}), 401
         
@@ -131,9 +124,18 @@ def get_user_from_token(request):
         if not user:
             raise Exception('Invalid session')
             
+        # Fetch user profile from the profiles table
+        # profile_response = supabase_client.table('profiles').select('role').eq('id', user.id).execute()
+        
+        #if not profile_response.data:
+        #    logger.error(f"No profile found for user {user.id}")
+        #    raise Exception('User profile not found')
+            
+        #role = profile_response.data[0]['role']
+            
         return {
             'email': user.email,
-            'role': user.user_metadata.get('role', 'customer')
+            'role': role
         }
     except Exception as e:
         logger.error(f"Error in get_user_from_token: {str(e)}")

--- a/backend/routes/tickets.py
+++ b/backend/routes/tickets.py
@@ -6,6 +6,7 @@ import traceback
 from .auth import requires_auth, get_user_from_token
 from utils.rag_utils import rag_service
 from utils.async_utils import async_route
+import uuid as uuid_pkg  # Rename to avoid conflict
 
 tickets_bp = Blueprint('tickets', __name__)
 
@@ -52,6 +53,9 @@ async def create_ticket():
         if not title or not description:
             return jsonify({'error': 'Title and description are required'}), 422
             
+        # Generate UUID for the ticket
+        ticket_uuid = str(uuid_pkg.uuid4())
+            
         # Insert ticket into Supabase
         ticket_data = {
             'user_email': email,
@@ -59,7 +63,11 @@ async def create_ticket():
             'description': description,
             'created_at': datetime.now().isoformat(),
             'status': 'open',
-            'assigned_to': None
+            'assignee': data.get('assignee', []),  # Get assignee from request or default to empty array
+            'username': user.get('user_metadata', {}).get('full_name', email),
+            'responses': [],
+            'related_uuids': [],
+            'uuid': ticket_uuid
         }
         
         logger.info(f"Inserting ticket data: {ticket_data}")
@@ -84,12 +92,19 @@ async def create_ticket():
                 ticket = result.data[0]
                 await rag_service.upsert_tickets([{
                     'id': str(ticket['id']),
+                    'uuid': ticket['uuid'],
                     'title': ticket['title'],
                     'content': ticket['description'],
                     'metadata': {
                         'user_email': ticket['user_email'],
                         'status': ticket['status'],
-                        'created_at': ticket['created_at']
+                        'created_at': ticket['created_at'],
+                        'updated_at': datetime.now().isoformat(),
+                        'uuid': ticket['uuid'],
+                        'username': ticket['username'],
+                        'assignee': ticket.get('assignee', []),
+                        'responses': ticket.get('responses', []),
+                        'related_uuids': ticket.get('related_uuids', [])
                     }
                 }])
                 return jsonify(ticket), 201
@@ -136,6 +151,9 @@ def get_tickets():
         if not client:
             return jsonify({'error': 'Failed to initialize Supabase client'}), 500
         
+        # Define fields to select
+        select_fields = ['*', 'username', 'responses', 'related_uuids', 'assignee']
+        
         # Query tickets based on role
         if role == 'customer':
             logger.info("Filtering tickets for customer")
@@ -143,8 +161,9 @@ def get_tickets():
             result = (
                 client
                 .table('tickets')
-                .select('*')
+                .select(','.join(select_fields))
                 .eq('user_email', email)
+                .order('created_at', desc=True)
                 .execute()
             )
         else:
@@ -153,12 +172,26 @@ def get_tickets():
             result = (
                 client
                 .table('tickets')
-                .select('*')
+                .select(','.join(select_fields))
+                .order('created_at', desc=True)
                 .execute()
             )
             
         logger.info(f"Query result: {result}")
-        return jsonify(result.data if hasattr(result, 'data') and result.data else [])
+        
+        # Process tickets to include additional metadata
+        if hasattr(result, 'data') and result.data:
+            tickets = result.data
+            for ticket in tickets:
+                # Ensure all array fields are initialized
+                ticket['responses'] = ticket.get('responses', [])
+                ticket['related_uuids'] = ticket.get('related_uuids', [])
+                ticket['assignee'] = ticket.get('assignee', [])
+                # Set username if not present
+                if not ticket.get('username'):
+                    ticket['username'] = ticket['user_email']
+            return jsonify(tickets)
+        return jsonify([])
         
     except Exception as e:
         logger.error(f"Error fetching tickets: {str(e)}")
@@ -192,11 +225,14 @@ def get_ticket(ticket_id):
         if not client:
             return jsonify({'error': 'Failed to initialize Supabase client'}), 500
         
+        # Define fields to select
+        select_fields = ['*', 'username', 'responses', 'related_uuids', 'assignee']
+        
         # Query specific ticket
         query = (
             client
             .table('tickets')
-            .select('*')
+            .select(','.join(select_fields))
             .eq('id', ticket_id)
         )
         
@@ -210,7 +246,17 @@ def get_ticket(ticket_id):
         if not hasattr(result, 'data') or not result.data:
             return jsonify({'error': 'Ticket not found'}), 404
             
-        return jsonify(result.data[0])
+        # Process ticket to include additional metadata
+        ticket = result.data[0]
+        # Ensure all array fields are initialized
+        ticket['responses'] = ticket.get('responses', [])
+        ticket['related_uuids'] = ticket.get('related_uuids', [])
+        ticket['assignee'] = ticket.get('assignee', [])
+        # Set username if not present
+        if not ticket.get('username'):
+            ticket['username'] = ticket['user_email']
+            
+        return jsonify(ticket)
         
     except Exception as e:
         logger.error(f"Error fetching ticket: {str(e)}")
@@ -265,11 +311,54 @@ async def update_ticket(ticket_id):
         if not hasattr(result, 'data') or not result.data:
             return jsonify({'error': 'Ticket not found or access denied'}), 404
             
+        current_ticket = result.data[0]
+        
+        # Prepare update data based on user role
+        update_data = {}
+        
+        # Customers can only update description and add responses
+        if role == 'customer':
+            if 'description' in data:
+                update_data['description'] = data['description']
+            if 'responses' in data:
+                # Append new responses to existing ones
+                current_responses = current_ticket.get('responses', [])
+                new_response = {
+                    'content': data['responses'][-1]['content'],
+                    'created_at': datetime.now().isoformat(),
+                    'user_email': email,
+                    'username': user.get('user_metadata', {}).get('full_name', email)
+                }
+                update_data['responses'] = current_responses + [new_response]
+        else:
+            # Agents can update all fields
+            allowed_fields = ['description', 'status', 'assignee', 'responses']
+            for field in allowed_fields:
+                if field in data:
+                    if field == 'responses' and data[field]:
+                        # Handle responses similar to customer case
+                        current_responses = current_ticket.get('responses', [])
+                        new_response = {
+                            'content': data['responses'][-1]['content'],
+                            'created_at': datetime.now().isoformat(),
+                            'user_email': email,
+                            'username': user.get('user_metadata', {}).get('full_name', email)
+                        }
+                        update_data['responses'] = current_responses + [new_response]
+                    else:
+                        update_data[field] = data[field]
+            
+            # Handle related_uuids separately to prevent accidental overwrites
+            if 'related_uuids' in data:
+                current_related = set(current_ticket.get('related_uuids', []))
+                new_related = set(data['related_uuids'])
+                update_data['related_uuids'] = list(current_related.union(new_related))
+        
         # Update the ticket
         update_result = (
             client
             .table('tickets')
-            .update(data)
+            .update(update_data)
             .eq('id', ticket_id)
             .execute()
         )
@@ -279,20 +368,299 @@ async def update_ticket(ticket_id):
             ticket = update_result.data[0]
             await rag_service.upsert_tickets([{
                 'id': str(ticket['id']),
+                'uuid': ticket['uuid'],
                 'title': ticket['title'],
                 'content': ticket['description'],
                 'metadata': {
                     'user_email': ticket['user_email'],
                     'status': ticket['status'],
                     'created_at': ticket['created_at'],
-                    'updated_at': datetime.now().isoformat()
+                    'updated_at': datetime.now().isoformat(),
+                    'uuid': ticket['uuid'],
+                    'username': ticket['username'],
+                    'assignee': ticket.get('assignee', []),
+                    'responses': ticket.get('responses', []),
+                    'related_uuids': ticket.get('related_uuids', [])
                 }
             }])
-            return jsonify(update_result.data[0])
+            return jsonify(ticket)
         else:
             return jsonify({'error': 'Failed to update ticket'}), 500
             
     except Exception as e:
         logger.error(f"Error updating ticket: {str(e)}")
+        logger.error(traceback.format_exc())
+        return jsonify({'error': str(e)}), 500
+
+@tickets_bp.route('/tickets/uuid/<string:uuid>', methods=['GET'])
+@requires_auth
+def get_ticket_by_uuid(uuid):
+    try:
+        # Get the raw token without 'Bearer ' prefix
+        auth_header = request.headers.get('Authorization', '')
+        token = auth_header.replace('Bearer ', '') if auth_header else None
+        refresh_token = request.headers.get('X-Refresh-Token')
+        
+        if not token or not refresh_token:
+            return jsonify({'error': 'No authorization tokens provided'}), 401
+            
+        # Get user from token
+        user = get_user_from_token(request)
+        if not user:
+            return jsonify({'error': 'Invalid token'}), 401
+            
+        email = user['email']
+        role = user['role']
+            
+        logger.info(f"Fetching ticket with UUID {uuid} for {email}")
+        
+        # Get Supabase client with session
+        client = get_supabase_client(token, refresh_token)
+        if not client:
+            return jsonify({'error': 'Failed to initialize Supabase client'}), 500
+        
+        # Define fields to select
+        select_fields = ['*', 'username', 'responses', 'related_uuids', 'assignee']
+        
+        # Query specific ticket by UUID
+        query = (
+            client
+            .table('tickets')
+            .select(','.join(select_fields))
+            .eq('uuid', uuid)
+        )
+        
+        if role == 'customer':
+            # Customers can only see their own tickets
+            query = query.eq('user_email', email)
+            
+        result = query.execute()
+        logger.info(f"Query result: {result}")
+        
+        if not hasattr(result, 'data') or not result.data:
+            return jsonify({'error': 'Ticket not found'}), 404
+            
+        # Process ticket to include additional metadata
+        ticket = result.data[0]
+        # Ensure all array fields are initialized
+        ticket['responses'] = ticket.get('responses', [])
+        ticket['related_uuids'] = ticket.get('related_uuids', [])
+        ticket['assignee'] = ticket.get('assignee', [])
+        # Set username if not present
+        if not ticket.get('username'):
+            ticket['username'] = ticket['user_email']
+            
+        return jsonify(ticket)
+        
+    except Exception as e:
+        logger.error(f"Error fetching ticket by UUID: {str(e)}")
+        logger.error(traceback.format_exc())
+        return jsonify({'error': str(e)}), 500
+
+# Add endpoint to get related tickets
+@tickets_bp.route('/tickets/<int:ticket_id>/related', methods=['GET'])
+@requires_auth
+def get_related_tickets(ticket_id):
+    try:
+        # Get the raw token without 'Bearer ' prefix
+        auth_header = request.headers.get('Authorization', '')
+        token = auth_header.replace('Bearer ', '') if auth_header else None
+        refresh_token = request.headers.get('X-Refresh-Token')
+        
+        if not token or not refresh_token:
+            return jsonify({'error': 'No authorization tokens provided'}), 401
+            
+        # Get user from token
+        user = get_user_from_token(request)
+        if not user:
+            return jsonify({'error': 'Invalid token'}), 401
+            
+        email = user['email']
+        role = user['role']
+            
+        logger.info(f"Fetching related tickets for ticket {ticket_id}")
+        
+        # Get Supabase client with session
+        client = get_supabase_client(token, refresh_token)
+        if not client:
+            return jsonify({'error': 'Failed to initialize Supabase client'}), 500
+        
+        # First get the current ticket to check access and get its UUID
+        current_ticket = (
+            client
+            .table('tickets')
+            .select('*, uuid')
+            .eq('id', ticket_id)
+        )
+        
+        if role == 'customer':
+            current_ticket = current_ticket.eq('user_email', email)
+            
+        result = current_ticket.execute()
+        
+        if not hasattr(result, 'data') or not result.data:
+            return jsonify({'error': 'Ticket not found or access denied'}), 404
+            
+        current_ticket_data = result.data[0]
+        current_uuid = current_ticket_data['uuid']
+        
+        # Get relationships where current ticket is either ticket_uuid_1 or ticket_uuid_2
+        relationships_1 = (
+            client
+            .table('ticket_relationships')
+            .select('ticket_uuid_2')
+            .eq('ticket_uuid_1', current_uuid)
+            .execute()
+        )
+        
+        relationships_2 = (
+            client
+            .table('ticket_relationships')
+            .select('ticket_uuid_1')
+            .eq('ticket_uuid_2', current_uuid)
+            .execute()
+        )
+        
+        # Combine related ticket UUIDs
+        related_uuids = []
+        
+        if hasattr(relationships_1, 'data') and relationships_1.data:
+            related_uuids.extend([r['ticket_uuid_2'] for r in relationships_1.data])
+            
+        if hasattr(relationships_2, 'data') and relationships_2.data:
+            related_uuids.extend([r['ticket_uuid_1'] for r in relationships_2.data])
+            
+        # Get related tickets
+        related_tickets = []
+        for uuid in related_uuids:
+            query = (
+                client
+                .table('tickets')
+                .select('*, uuid')
+                .eq('uuid', uuid)
+            )
+            
+            if role == 'customer':
+                query = query.eq('user_email', email)
+                
+            ticket_result = query.execute()
+            if hasattr(ticket_result, 'data') and ticket_result.data:
+                related_tickets.append(ticket_result.data[0])
+        
+        return jsonify({
+            'current_ticket': current_ticket_data,
+            'related_tickets': related_tickets
+        })
+        
+    except Exception as e:
+        logger.error(f"Error fetching related tickets: {str(e)}")
+        logger.error(traceback.format_exc())
+        return jsonify({'error': str(e)}), 500
+
+@tickets_bp.route('/tickets/<int:ticket_id>/link', methods=['POST'])
+@requires_auth
+def link_tickets(ticket_id):
+    try:
+        # Get the raw token without 'Bearer ' prefix
+        auth_header = request.headers.get('Authorization', '')
+        token = auth_header.replace('Bearer ', '') if auth_header else None
+        refresh_token = request.headers.get('X-Refresh-Token')
+        
+        if not token or not refresh_token:
+            return jsonify({'error': 'No authorization tokens provided'}), 401
+            
+        # Get user from token
+        user = get_user_from_token(request)
+        if not user:
+            return jsonify({'error': 'Invalid token'}), 401
+            
+        email = user['email']
+        role = user['role']
+            
+        data = request.get_json()
+        if not data or 'related_uuid' not in data:
+            return jsonify({'error': 'Related ticket UUID is required'}), 400
+            
+        related_uuid = data['related_uuid']
+        logger.info(f"Linking ticket {ticket_id} with ticket UUID {related_uuid}")
+        
+        # Get Supabase client with session
+        client = get_supabase_client(token, refresh_token)
+        if not client:
+            return jsonify({'error': 'Failed to initialize Supabase client'}), 500
+        
+        # First get the current ticket to check access and get its UUID
+        current_ticket = (
+            client
+            .table('tickets')
+            .select('*')
+            .eq('id', ticket_id)
+        )
+        
+        if role == 'customer':
+            current_ticket = current_ticket.eq('user_email', email)
+            
+        result = current_ticket.execute()
+        
+        if not hasattr(result, 'data') or not result.data:
+            return jsonify({'error': 'Ticket not found or access denied'}), 404
+            
+        current_ticket_data = result.data[0]
+        current_uuid = current_ticket_data['uuid']
+        
+        # Check if the related ticket exists
+        related_ticket = (
+            client
+            .table('tickets')
+            .select('*')
+            .eq('uuid', related_uuid)
+        )
+        
+        if role == 'customer':
+            related_ticket = related_ticket.eq('user_email', email)
+            
+        related_result = related_ticket.execute()
+        
+        if not hasattr(related_result, 'data') or not related_result.data:
+            return jsonify({'error': 'Related ticket not found or access denied'}), 404
+            
+        # Create or update ticket relationships
+        # First check if relationship already exists
+        existing_relationship = (
+            client
+            .table('ticket_relationships')
+            .select('*')
+            .eq('uuid_1', current_uuid)
+            .eq('uuid_2', related_uuid)
+            .execute()
+        )
+        
+        if not hasattr(existing_relationship, 'data') or not existing_relationship.data:
+            # Create new relationship
+            relationship_data = {
+                'uuid_1': current_uuid,
+                'uuid_2': related_uuid,
+                'created_at': datetime.now().isoformat(),
+                'created_by': email
+            }
+            
+            relationship_result = (
+                client
+                .table('ticket_relationships')
+                .insert(relationship_data)
+                .execute()
+            )
+            
+            if not hasattr(relationship_result, 'data'):
+                return jsonify({'error': 'Failed to create ticket relationship'}), 500
+                
+        return jsonify({
+            'message': 'Tickets linked successfully',
+            'ticket_1': current_ticket_data,
+            'ticket_2': related_result.data[0]
+        })
+        
+    except Exception as e:
+        logger.error(f"Error linking tickets: {str(e)}")
         logger.error(traceback.format_exc())
         return jsonify({'error': str(e)}), 500 

--- a/backend/routes/users.py
+++ b/backend/routes/users.py
@@ -1,0 +1,44 @@
+from flask import Blueprint, jsonify, request
+from config import supabase_client, logger
+import traceback
+from .auth import requires_auth, get_user_from_token
+
+users_bp = Blueprint('users', __name__)
+
+@users_bp.route('/users/agents', methods=['GET'])
+@requires_auth
+def get_agents():
+    try:
+        # Get user from token for role verification
+        user = get_user_from_token(request)
+        if not user:
+            return jsonify({'error': 'Invalid token'}), 401
+            
+        role = user['role']
+        if role != 'agent':
+            return jsonify({'error': 'Unauthorized access'}), 403
+
+        try:
+            # Use regular client to fetch users with agent role
+            response = supabase_client.table('users').select('id, email, metadata').eq('role', 'agent').execute()
+            users = response.data if response else []
+            
+            # Format response
+            agents = []
+            for user in users:
+                agents.append({
+                    'id': user['id'],
+                    'email': user['email'],
+                    'name': user['metadata'].get('full_name', user['email'])
+                })
+            
+            return jsonify(agents)
+            
+        except Exception as e:
+            logger.error(f"Error in Supabase operation: {str(e)}")
+            return jsonify({'error': 'Failed to fetch agents'}), 500
+        
+    except Exception as e:
+        logger.error(f"Error fetching agents: {str(e)}")
+        logger.error(traceback.format_exc())
+        return jsonify({'error': str(e)}), 500 

--- a/web/src/pages/Dashboard.tsx
+++ b/web/src/pages/Dashboard.tsx
@@ -5,6 +5,10 @@ import { DataTable } from 'primereact/datatable';
 import { Column } from 'primereact/column';
 import { Message } from 'primereact/message';
 import { fetchWithAuth } from '../utils/api';
+import { Tag } from 'primereact/tag';
+import { Avatar } from 'primereact/avatar';
+import { AvatarGroup } from 'primereact/avatargroup';
+import { Tooltip } from 'primereact/tooltip';
 import './Dashboard.css';
 
 interface Ticket {
@@ -14,7 +18,15 @@ interface Ticket {
   status: string;
   created_at: string;
   user_email: string;
-  assigned_to?: string;
+  username: string;
+  assignee: string[];
+  responses: Array<{
+    content: string;
+    created_at: string;
+    user_email: string;
+    username: string;
+  }>;
+  related_uuids: string[];
 }
 
 const Dashboard: React.FC = () => {
@@ -61,7 +73,7 @@ const Dashboard: React.FC = () => {
       { key: 'description', label: 'Description' },
       { key: 'status', label: 'Status' },
       { key: 'user_email', label: 'Created By' },
-      { key: 'assigned_to', label: 'Assigned To' }
+      { key: 'assignee', label: 'Assigned To' }
     ];
 
     // Build the formatted query string
@@ -75,6 +87,71 @@ const Dashboard: React.FC = () => {
       .join('\n');
 
     navigate('/rag-search', { state: { initialQuery: formattedFields } });
+  };
+
+  const assigneeBodyTemplate = (rowData: Ticket) => {
+    if (!rowData.assignee || rowData.assignee.length === 0) {
+      return <span className="text-500">Unassigned</span>;
+    }
+
+    return (
+      <>
+        <AvatarGroup className="justify-content-start">
+          {rowData.assignee.slice(0, 3).map((email, index) => (
+            <Avatar
+              key={index}
+              label={email.charAt(0).toUpperCase()}
+              size="normal"
+              shape="circle"
+              className="custom-avatar"
+            />
+          ))}
+          {rowData.assignee.length > 3 && (
+            <Avatar 
+              label={`+${rowData.assignee.length - 3}`}
+              size="normal"
+              shape="circle"
+              className="custom-avatar-more"
+            />
+          )}
+        </AvatarGroup>
+        <Tooltip target=".custom-avatar, .custom-avatar-more">
+          <div className="flex flex-column">
+            {rowData.assignee.map((email, index) => (
+              <span key={index}>{email}</span>
+            ))}
+          </div>
+        </Tooltip>
+      </>
+    );
+  };
+
+  const statusBodyTemplate = (rowData: Ticket) => {
+    const getSeverity = (status: string) => {
+      switch (status.toLowerCase()) {
+        case 'open':
+          return 'info';
+        case 'in_progress':
+          return 'warning';
+        case 'resolved':
+          return 'success';
+        case 'closed':
+          return 'danger';
+        default:
+          return null;
+      }
+    };
+
+    return (
+      <Tag 
+        value={rowData.status.replace('_', ' ')} 
+        severity={getSeverity(rowData.status)}
+      />
+    );
+  };
+
+  const dateBodyTemplate = (rowData: Ticket) => {
+    return new Date(rowData.created_at).toLocaleDateString();
   };
 
   const actionBodyTemplate = (rowData: Ticket) => {
@@ -97,18 +174,6 @@ const Dashboard: React.FC = () => {
           tooltip="Search Knowledge Base"
         />
       </div>
-    );
-  };
-
-  const dateBodyTemplate = (rowData: Ticket) => {
-    return new Date(rowData.created_at).toLocaleDateString();
-  };
-
-  const statusBodyTemplate = (rowData: Ticket) => {
-    return (
-      <span className={`status-badge status-${rowData.status.toLowerCase()}`}>
-        {rowData.status}
-      </span>
     );
   };
 
@@ -140,15 +205,15 @@ const Dashboard: React.FC = () => {
           <Column field="id" header="ID" sortable style={{ width: '5%' }} />
           <Column field="title" header="Title" sortable style={{ width: '25%' }} />
           <Column field="status" header="Status" body={statusBodyTemplate} sortable style={{ width: '10%' }} />
-          <Column field="user_email" header="Created By" sortable style={{ width: '20%' }} />
+          <Column field="username" header="Created By" sortable style={{ width: '15%' }} />
           <Column field="created_at" header="Created At" body={dateBodyTemplate} sortable style={{ width: '15%' }} />
           {userRole === 'agent' && (
             <Column
-              field="assigned_to"
+              field="assignee"
               header="Assigned To"
-              body={(rowData) => rowData.assigned_to || 'Unassigned'}
+              body={assigneeBodyTemplate}
               sortable
-              style={{ width: '15%' }}
+              style={{ width: '20%' }}
             />
           )}
           <Column body={actionBodyTemplate} header="Actions" style={{ width: '10%' }} />

--- a/web/src/pages/Dashboard.tsx
+++ b/web/src/pages/Dashboard.tsx
@@ -54,16 +54,49 @@ const Dashboard: React.FC = () => {
     navigate(`/edit-ticket/${ticketId}`);
   };
 
+  const handleRagSearch = (ticket: Ticket) => {
+    // Define ticket fields to display and their labels
+    const ticketFields: Array<{key: keyof Ticket; label: string}> = [
+      { key: 'title', label: 'Title' },
+      { key: 'description', label: 'Description' },
+      { key: 'status', label: 'Status' },
+      { key: 'user_email', label: 'Created By' },
+      { key: 'assigned_to', label: 'Assigned To' }
+    ];
+
+    // Build the formatted query string
+    const formattedFields = ticketFields
+      .map(field => {
+        const value = ticket[field.key];
+        // Only include the field if it has a value
+        return value ? `**${field.label}:** ${value}\n` : null;
+      })
+      .filter(Boolean) // Remove null entries
+      .join('\n');
+
+    navigate('/rag-search', { state: { initialQuery: formattedFields } });
+  };
+
   const actionBodyTemplate = (rowData: Ticket) => {
     return (
-      <Button
-        icon="pi pi-pencil"
-        rounded
-        text
-        severity="info"
-        onClick={() => handleEditTicket(rowData.id)}
-        tooltip="Edit Ticket"
-      />
+      <div className="flex gap-2">
+        <Button
+          icon="pi pi-pencil"
+          rounded
+          text
+          severity="info"
+          onClick={() => handleEditTicket(rowData.id)}
+          tooltip="Edit Ticket"
+        />
+        <Button
+          icon="pi pi-search"
+          rounded
+          text
+          severity="help"
+          onClick={() => handleRagSearch(rowData)}
+          tooltip="Search Knowledge Base"
+        />
+      </div>
     );
   };
 


### PR DESCRIPTION
Added new ticket response generation workflow:
- Added a new magnifying glass button beside each ticket's edit button
  - When this button is clicked it opens a new RAG query with the Ticket information
  - The preserved info populated in a non-editable text box and included in the query to the LLM
  - Added a "Generate Response" Button visible when ticket information is being included in the context
  - The default prompt can be changed according to user needs